### PR TITLE
Fix multiple memory leaks in codedoc.c

### DIFF
--- a/codedoc.c
+++ b/codedoc.c
@@ -3117,8 +3117,10 @@ scan_file(filebuf_t   *file,		/* I  - File to scan */
 		    next_string = get_nth_text(type, 1, NULL);
 		  }
 		  else
+		  {
+        mxmlDelete(typedefnode);
 		    typedefnode = NULL;
-
+      }
 		  enumeration = mxmlNewElement(MXML_NO_PARENT, "enumeration");
 
                   DEBUG_printf("Enumeration: <<<< %s >>>\n", next_string ? next_string : "(noname)");
@@ -4239,6 +4241,8 @@ scan_file(filebuf_t   *file,		/* I  - File to scan */
   }
 
   mxmlDelete(comment);
+  mxmlDelete(function);
+  mxmlDelete(type);
 
  /*
   * All done, return with no errors...


### PR DESCRIPTION
Hi,
I am a new contributor to codedoc.

I found multiple memory leaks on running the following inputs :
[poc250.txt](https://github.com/michaelrsweet/codedoc/files/14130733/poc250.txt)
[poc188.txt](https://github.com/michaelrsweet/codedoc/files/14130736/poc188.txt)


Memory leaks in poc250:
```
> =================================================================
> ==85050==ERROR: LeakSanitizer: detected memory leaks
> 
> Indirect leak of 9064 byte(s) in 103 object(s) allocated from:
>     #0 0x4c1847 in calloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:154:3
>     #1 0x54f969 in mxml_new /home/aniruddhan/mxml/mxml-node.c:836:15
> 
> Indirect leak of 251 byte(s) in 83 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x54fe4f in mxmlNewText /home/aniruddhan/mxml/mxml-node.c:571:35
> 
> Indirect leak of 70 byte(s) in 9 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x54fab5 in mxmlNewElement /home/aniruddhan/mxml/mxml-node.c:383:32
>     #2 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #3 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #4 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #5 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #6 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 64 byte(s) in 4 object(s) allocated from:
>     #0 0x4c168f in malloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
>     #1 0x544c02 in mxml_set_attr /home/aniruddhan/mxml/mxml-attr.c:322:12
> 
> Indirect leak of 28 byte(s) in 1 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x55152a in mxmlSetOpaque /home/aniruddhan/mxml/mxml-set.c:252:12
>     #2 0x5006cc in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:3864:3
>     #3 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #4 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #5 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #6 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 26 byte(s) in 3 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x54fab5 in mxmlNewElement /home/aniruddhan/mxml/mxml-node.c:383:32
>     #2 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #3 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 23 byte(s) in 1 object(s) allocated from:
>     #0 0x4c168f in malloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
>     #1 0x7f4d87b0dc47 in __vasprintf_internal /build/glibc-wuryBv/glibc-2.31/libio/vasprintf.c:71:30
> 
> Indirect leak of 20 byte(s) in 4 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x544c5a in mxml_set_attr /home/aniruddhan/mxml/mxml-attr.c:337:21
> 
> Indirect leak of 18 byte(s) in 2 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x54fab5 in mxmlNewElement /home/aniruddhan/mxml/mxml-node.c:383:32
>     #2 0x502463 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:4082:23
>     #3 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #4 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #5 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #6 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #7 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 17 byte(s) in 2 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x54fab5 in mxmlNewElement /home/aniruddhan/mxml/mxml-node.c:383:32
>     #2 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #3 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #4 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #5 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 7 byte(s) in 2 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x544a32 in mxmlElementSetAttr /home/aniruddhan/mxml/mxml-attr.c:221:19
>     #2 0x502463 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:4082:23
>     #3 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #4 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #5 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #6 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #7 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 7 byte(s) in 1 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x55152a in mxmlSetOpaque /home/aniruddhan/mxml/mxml-set.c:252:12
>     #2 0x502031 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:4053:5
>     #3 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #4 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #5 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #6 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #7 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 6 byte(s) in 1 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x544a32 in mxmlElementSetAttr /home/aniruddhan/mxml/mxml-attr.c:221:19
>     #2 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #3 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 5 byte(s) in 1 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x54fab5 in mxmlNewElement /home/aniruddhan/mxml/mxml-node.c:383:32
>     #2 0x4fa642 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:2945:24
>     #3 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #4 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> Indirect leak of 4 byte(s) in 1 object(s) allocated from:
>     #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
>     #1 0x55152a in mxmlSetOpaque /home/aniruddhan/mxml/mxml-set.c:252:12
>     #2 0x502157 in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:4063:3
>     #3 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
>     #4 0x7f4d87aa6082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
> 
> SUMMARY: AddressSanitizer: 9610 byte(s) leaked in 218 allocation(s).
```

Memory leaks in poc188:

```
=================================================================
==85155==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 264 byte(s) in 3 object(s) allocated from:
    #0 0x4c1847 in calloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:154:3
    #1 0x54f969 in mxml_new /home/aniruddhan/mxml/mxml-node.c:836:15

Indirect leak of 27 byte(s) in 1 object(s) allocated from:
    #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
    #1 0x55152a in mxmlSetOpaque /home/aniruddhan/mxml/mxml-set.c:252:12
    #2 0x4fbf2f in scan_file /home/aniruddhan/mxml/codedoc/codedoc.c:3162:7
    #3 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
    #4 0x7fe9d64f7082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16

Indirect leak of 20 byte(s) in 2 object(s) allocated from:
    #0 0x43bbf7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
    #1 0x54fab5 in mxmlNewElement /home/aniruddhan/mxml/mxml-node.c:383:32
    #2 0x4f85e7 in main /home/aniruddhan/mxml/codedoc/codedoc.c:532:12
    #3 0x7fe9d64f7082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16

SUMMARY: AddressSanitizer: 311 byte(s) leaked in 6 allocation(s).
```


I was able to patch multiple of these leaks by freeing `function` and `type` (which are mxml_node_t) at the end of `scan_file` before return. This fixes the leaks from poc250.  Additionally the patch frees typedefnode before assigning it to NULL to fix a few other leaks in poc188.


After inserting the patch I was able to verify the leaks were no longer occuring through leaksanitizer.  This also patches https://github.com/michaelrsweet/mxml/issues/305 in mxml.

Please let me know if the patch is helpful to the repository :)
